### PR TITLE
Add optional context to _.result

### DIFF
--- a/test/utility.js
+++ b/test/utility.js
@@ -216,6 +216,13 @@ $(document).ready(function() {
     strictEqual(_.result(null, 'x'), undefined);
   });
 
+  test('result calls with context if passed in', function() {
+    var obj = { f: function() { return this; }, p: 1 }, ctx = new function(){};
+    strictEqual(_.result(obj, 'f'), obj);
+    strictEqual(_.result(obj, 'f', ctx), ctx);
+    strictEqual(_.result(obj, 'p'), 1);
+  });
+
   test('_.templateSettings.variable', function() {
     var s = '<%=data.x%>';
     var data = {x: 'x'};

--- a/underscore.js
+++ b/underscore.js
@@ -1086,11 +1086,11 @@
   });
 
   // If the value of the named `property` is a function then invoke it with the
-  // `object` as context; otherwise, return it.
-  _.result = function(object, property) {
+  // `object` as context or the optional third parameter `context`; otherwise, return it.
+  _.result = function(object, property, context) {
     if (object == null) return void 0;
     var value = object[property];
-    return _.isFunction(value) ? value.call(object) : value;
+    return _.isFunction(value) ? value.call(arguments.length > 2 ? context : object) : value;
   };
 
   // Add your own custom functions to the Underscore object.


### PR DESCRIPTION
I added an optional third `context` parameter to `_.result`. This is useful for when you want to use `_.result` with a prototype object.

I'm using it to extend the `events` object in a `Backbone.View` like this:

```
var BaseView = Backbone.View.extend({
  events: { 'click': 'onClick' }
});

var ExtendedView = BaseView.extend({
  events: function() {
    return _.extend({
      'click .something-else': 'onClickSomethingElse'
    }, _.result(BaseView.prototype, 'events', this));
  }
});
```
